### PR TITLE
Fix PS2_KEY_PAUSE value (my attempt without having v1.0.10)

### DIFF
--- a/src/PS2KeyAdvanced.cpp
+++ b/src/PS2KeyAdvanced.cpp
@@ -382,6 +382,9 @@ switch( value )
                 state = 4;
                 break;
    case PS2_KC_EXTEND1:   // Major extend code (PAUSE key only)
+                //  PS2 Keyboard don't send break code when Pause/Break key is physically released, but immediately after the make code.
+                //   On Make, it sends make CTRL+numlock then immediatly the break codes for that: E1 14 77  E1 F0 14 F0 77
+                //  PS2_KC_EXTEND1 PS2_KC_CTRL PS2_KC_NUM then PS2_KC_EXTEND1 PS2_KC_KEYBREAK PS2_KC_CTRL PS2_KC_KEYBREAK PS2_KC_NUM
                 if( !( _ps2mode & _E1_MODE ) )  // First E1 only
                   {
                   _bytes_expected = 7;       // seven more bytes
@@ -665,6 +668,7 @@ index++;
 if( index >= _RX_BUFFER_SIZE )
   index = 0;
 _tail = index;
+
 // Get the flags byte break modes etc in this order
 data = _rx_buffer[ index ] & 0xFF;
 index = ( _rx_buffer[ index ] & 0xFF00 ) >> 8;

--- a/src/PS2KeyAdvanced.cpp
+++ b/src/PS2KeyAdvanced.cpp
@@ -669,10 +669,6 @@ _tail = index;
 data = _rx_buffer[ index ] & 0xFF;
 index = ( _rx_buffer[ index ] & 0xFF00 ) >> 8;
 
-// Catch special case of PAUSE key
-if( index & _E1_MODE )
-  return  PS2_KEY_PAUSE + _FUNCTION;
-
 // Ignore anything not actual keycode but command/response
 // Return untranslated as valid
 if( ( data >= PS2_KC_BAT && data != PS2_KC_LANG1 && data != PS2_KC_LANG2 )
@@ -686,6 +682,12 @@ else
   PS2_keystatus &= ~_BREAK;
 
 retdata = 0;    // error code by default
+
+// Catch special case of PAUSE key
+if( index & _E1_MODE ) {
+  retdata = PS2_KEY_PAUSE;
+  PS2_keystatus |= _FUNCTION;
+} else
 // Scan appropriate table
 if( index & _E0_MODE )
   {


### PR DESCRIPTION
Hi,
Here my attempt to fix PS2_KEY_PAUSE returned value (was : 0x6 instead of 0x5) to address issues https://github.com/techpaul/PS2KeyAdvanced/issues/35, https://github.com/techpaul/PS2KeyAdvanced/issues/26, https://github.com/techpaul/PS2KeyAdvanced/issues/5.

I checked that, in translate(), variable data equals to 0x77 when processing the Pause/break key special case, so it seems that there is no side effect of move the code section near the if ( ... & _E1_MODE ) case, that is after the

if( ( data >= PS2_KC_BAT && data != PS2_KC_LANG1 && data != PS2_KC_LANG2 )
check.